### PR TITLE
feat: add app-connector mode, update providers, and improve module interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,66 @@
 # terraform-aws-tailscale
-terraform module for a tailscle host
 
-Configure your tailscal provider with the following env vars:
+Terraform module for deploying a Tailscale bastion host on AWS EC2.
+
+## Overview
+
+This module creates an EC2 instance that connects to your Tailscale network and advertises routes to your VPC. This allows you to securely access private AWS resources from any device on your Tailscale network without exposing them to the public internet.
+
+**What gets created:**
+- EC2 instance (t4g.micro ARM64) running Tailscale
+- Security group (egress-only, ingress handled by Tailscale)
+- KMS key for EBS encryption
+- Tailscale auth key for automatic node registration
+
+## Prerequisites
+
+1. **Tailscale account** with admin access
+2. **OAuth client** created in Tailscale admin console with:
+   - `devices:write` scope (to register the bastion)
+   - Tags configured that match your `tailscale_tags` variable
+
+## Provider Configuration
+
+Set the following environment variables:
+
+```bash
+export TAILSCALE_OAUTH_CLIENT_ID="your-client-id"
+export TAILSCALE_OAUTH_CLIENT_SECRET="your-client-secret"
 ```
-TAILSCALE_OAUTH_CLIENT_ID
-TAILSCALE_OAUTH_CLIENT_SECRET
-```
-add the following to your provider block:
+
+Add the provider block to your Terraform configuration:
+
 ```hcl
 provider "tailscale" {}
 ```
-Ensure the tags passed in to input_tags are valid for the oauth client you created.
 
-This module is currently only tested to run in a public subnet.
+## Usage
 
+```hcl
+module "tailscale_bastion" {
+  source  = "DoneOps/tailscale/aws"
+  version = "0.1.10"
+
+  name              = "production"
+  vpc_id            = "vpc-0123456789abcdef0"
+  subnet_id         = "subnet-0123456789abcdef0"
+  advertised_routes = ["10.0.0.0/16"]
+  tailscale_tags    = ["tag:bastion"]
+
+  tags = {
+    Environment = "production"
+  }
+}
+```
+
+## How It Works
+
+1. The module launches an Amazon Linux 2 EC2 instance in your specified subnet
+2. On boot, the instance installs Tailscale and authenticates using the generated auth key
+3. The instance advertises your VPC CIDR ranges to the Tailscale network
+4. Devices on your Tailscale network can now route traffic to your VPC through this bastion
+
+**Note:** This module requires a public subnet with internet access. The bastion needs outbound connectivity to reach Tailscale's coordination servers.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -22,20 +69,20 @@ This module is currently only tested to run in a public subnet.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.5.6 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.20 |
-| <a name="requirement_tailscale"></a> [tailscale](#requirement\_tailscale) | 0.15.0 |
+| <a name="requirement_tailscale"></a> [tailscale](#requirement\_tailscale) | 0.25.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.40.0 |
-| <a name="provider_tailscale"></a> [tailscale](#provider\_tailscale) | 0.15.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.20 |
+| <a name="provider_tailscale"></a> [tailscale](#provider\_tailscale) | 0.25.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ebs_kms_key"></a> [ebs\_kms\_key](#module\_ebs\_kms\_key) | terraform-aws-modules/kms/aws | 2.2.1 |
+| <a name="module_ebs_kms_key"></a> [ebs\_kms\_key](#module\_ebs\_kms\_key) | terraform-aws-modules/kms/aws | 4.2.0 |
 
 ## Resources
 
@@ -43,7 +90,7 @@ This module is currently only tested to run in a public subnet.
 |------|------|
 | [aws_instance.bastion_host_ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_security_group.allow_bastion_ssh_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [tailscale_tailnet_key.bastion_key](https://registry.terraform.io/providers/tailscale/tailscale/0.15.0/docs/resources/tailnet_key) | resource |
+| [tailscale_tailnet_key.bastion_key](https://registry.terraform.io/providers/tailscale/tailscale/0.25.0/docs/resources/tailnet_key) | resource |
 | [aws_ami.amazon2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_session_context.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_session_context) | data source |
@@ -56,8 +103,9 @@ This module is currently only tested to run in a public subnet.
 | <a name="input_accept_dns"></a> [accept\_dns](#input\_accept\_dns) | For EC2 instances it is generally best to let Amazon handle the DNS configuration, not have Tailscale override it | `bool` | `false` | no |
 | <a name="input_advertised_routes"></a> [advertised\_routes](#input\_advertised\_routes) | List of advertised routes for the bastion host | `list(string)` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Stack name to use in resource creation | `string` | n/a | yes |
-| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Subnet in which to dpeloy the ec2 instance | `string` | n/a | yes |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Subnet in which to deploy the EC2 instance | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+| <a name="input_tailscale_tags"></a> [tailscale\_tags](#input\_tailscale\_tags) | List of tags to apply to the Tailscale node | `list(string)` | `["tag:bastion"]` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID | `string` | n/a | yes |
 
 ## Outputs
@@ -65,5 +113,5 @@ This module is currently only tested to run in a public subnet.
 | Name | Description |
 |------|-------------|
 | <a name="output_incoming_security_group_id"></a> [incoming\_security\_group\_id](#output\_incoming\_security\_group\_id) | Security group ID for bastion sg |
-| <a name="output_instance_id"></a> [instance\_id](#output\_instance\_id) | n/a |
+| <a name="output_instance_id"></a> [instance\_id](#output\_instance\_id) | EC2 instance ID of the bastion host |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # terraform-aws-tailscale
 
-Terraform module for deploying a Tailscale bastion host on AWS EC2.
+Terraform module for deploying a Tailscale node on AWS EC2 as either a **subnet router** or **app connector**.
 
 ## Overview
 
-This module creates an EC2 instance that connects to your Tailscale network and advertises routes to your VPC. This allows you to securely access private AWS resources from any device on your Tailscale network without exposing them to the public internet.
+This module creates an EC2 instance that connects to your Tailscale network. It supports two modes:
+
+- **Subnet Router** (default): Advertises IP routes to your VPC, allowing Tailscale devices to access private resources by IP address
+- **App Connector**: Advertises itself as a connector for DNS-based routing, ideal for environments with overlapping CIDRs
 
 **What gets created:**
 - EC2 instance (t4g.micro ARM64) running Tailscale
@@ -16,7 +19,7 @@ This module creates an EC2 instance that connects to your Tailscale network and 
 
 1. **Tailscale account** with admin access
 2. **OAuth client** created in Tailscale admin console with:
-   - `devices:write` scope (to register the bastion)
+   - `devices:write` scope (to register the node)
    - Tags configured that match your `tailscale_tags` variable
 
 ## Provider Configuration
@@ -36,10 +39,14 @@ provider "tailscale" {}
 
 ## Usage
 
+### Subnet Router Mode (Default)
+
+Use subnet router mode when you want to expose VPC resources by IP address. Best for single environments or when CIDRs don't overlap.
+
 ```hcl
 module "tailscale_bastion" {
   source  = "DoneOps/tailscale/aws"
-  version = "0.1.10"
+  version = "0.2.0"
 
   name              = "production"
   vpc_id            = "vpc-0123456789abcdef0"
@@ -53,14 +60,98 @@ module "tailscale_bastion" {
 }
 ```
 
+### App Connector Mode
+
+Use app connector mode when you have multiple environments with overlapping VPC CIDRs. Routes traffic by DNS name instead of IP address.
+
+```hcl
+module "tailscale_connector" {
+  source  = "DoneOps/tailscale/aws"
+  version = "0.2.0"
+
+  name           = "staging"
+  mode           = "app-connector"
+  vpc_id         = "vpc-0123456789abcdef0"
+  subnet_id      = "subnet-0123456789abcdef0"
+  tailscale_tags = ["tag:staging-connector"]
+
+  tags = {
+    Environment = "staging"
+  }
+}
+```
+
+**Important:** App connector domains are configured in your Tailscale ACL policy, not in Terraform. See [ACL Configuration](#app-connector-acl-configuration) below.
+
 ## How It Works
 
+### Subnet Router
 1. The module launches an Amazon Linux 2 EC2 instance in your specified subnet
 2. On boot, the instance installs Tailscale and authenticates using the generated auth key
 3. The instance advertises your VPC CIDR ranges to the Tailscale network
-4. Devices on your Tailscale network can now route traffic to your VPC through this bastion
+4. Devices on your Tailscale network can route traffic to your VPC through this node
 
-**Note:** This module requires a public subnet with internet access. The bastion needs outbound connectivity to reach Tailscale's coordination servers.
+### App Connector
+1. The module launches an EC2 instance configured as an app connector
+2. The instance registers with Tailscale using `--advertise-connector`
+3. Domains are configured in your Tailscale ACL policy (Admin Console)
+4. The connector resolves DNS names and automatically advertises routes for discovered IPs
+5. Traffic for configured domains flows through the connector
+
+**Note:** This module requires a public subnet with internet access. The node needs outbound connectivity to reach Tailscale's coordination servers.
+
+## App Connector ACL Configuration
+
+After deploying in app-connector mode, configure your Tailscale ACL policy:
+
+### 1. Tag Owners
+
+```json
+"tagOwners": {
+  "tag:staging-connector": ["autogroup:admin"]
+}
+```
+
+### 2. Auto-Approvers
+
+```json
+"autoApprovers": {
+  "routes": {
+    "0.0.0.0/0": ["tag:staging-connector"],
+    "::/0": ["tag:staging-connector"]
+  }
+}
+```
+
+### 3. App Configuration
+
+```json
+"nodeAttrs": [{
+  "target": ["tag:staging-connector"],
+  "app": {
+    "tailscale.com/app-connectors": [{
+      "name": "AWS Staging",
+      "connectors": ["tag:staging-connector"],
+      "domains": [
+        "*.us-east-1.rds.amazonaws.com",
+        "*.us-east-1.redshift.amazonaws.com",
+        "*.us-east-1.es.amazonaws.com",
+        "*.elasticache.amazonaws.com"
+      ]
+    }]
+  }
+}]
+```
+
+## Subnet Router vs App Connector
+
+| Feature | Subnet Router | App Connector |
+|---------|---------------|---------------|
+| Routing | By IP/CIDR | By DNS name |
+| Overlapping CIDRs | Causes conflicts | Works fine |
+| Configuration | Terraform only | Terraform + ACL policy |
+| Access granularity | IP ranges | Specific domains |
+| Best for | Single environment | Multi-environment |
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -69,14 +160,14 @@ module "tailscale_bastion" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.5.6 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.20 |
-| <a name="requirement_tailscale"></a> [tailscale](#requirement\_tailscale) | 0.25.0 |
+| <a name="requirement_tailscale"></a> [tailscale](#requirement\_tailscale) | >= 0.18.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.20 |
-| <a name="provider_tailscale"></a> [tailscale](#provider\_tailscale) | 0.25.0 |
+| <a name="provider_tailscale"></a> [tailscale](#provider\_tailscale) | >= 0.18.0 |
 
 ## Modules
 
@@ -90,7 +181,7 @@ module "tailscale_bastion" {
 |------|------|
 | [aws_instance.bastion_host_ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_security_group.allow_bastion_ssh_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [tailscale_tailnet_key.bastion_key](https://registry.terraform.io/providers/tailscale/tailscale/0.25.0/docs/resources/tailnet_key) | resource |
+| [tailscale_tailnet_key.bastion_key](https://registry.terraform.io/providers/tailscale/tailscale/latest/docs/resources/tailnet_key) | resource |
 | [aws_ami.amazon2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_session_context.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_session_context) | data source |
@@ -101,7 +192,8 @@ module "tailscale_bastion" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_accept_dns"></a> [accept\_dns](#input\_accept\_dns) | For EC2 instances it is generally best to let Amazon handle the DNS configuration, not have Tailscale override it | `bool` | `false` | no |
-| <a name="input_advertised_routes"></a> [advertised\_routes](#input\_advertised\_routes) | List of advertised routes for the bastion host | `list(string)` | n/a | yes |
+| <a name="input_advertised_routes"></a> [advertised\_routes](#input\_advertised\_routes) | List of advertised routes for the bastion host (only used in subnet-router mode) | `list(string)` | `[]` | no |
+| <a name="input_mode"></a> [mode](#input\_mode) | Tailscale mode: 'subnet-router' or 'app-connector' | `string` | `"subnet-router"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Stack name to use in resource creation | `string` | n/a | yes |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Subnet in which to deploy the EC2 instance | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
@@ -115,3 +207,9 @@ module "tailscale_bastion" {
 | <a name="output_incoming_security_group_id"></a> [incoming\_security\_group\_id](#output\_incoming\_security\_group\_id) | Security group ID for bastion sg |
 | <a name="output_instance_id"></a> [instance\_id](#output\_instance\_id) | EC2 instance ID of the bastion host |
 <!-- END_TF_DOCS -->
+
+## References
+
+- [Tailscale Subnet Routers](https://tailscale.com/kb/1019/subnets)
+- [Tailscale App Connectors](https://tailscale.com/kb/1281/app-connectors)
+- [App Connector Setup Guide](https://tailscale.com/kb/1342/app-connectors-setup)

--- a/README.md
+++ b/README.md
@@ -193,11 +193,12 @@ After deploying in app-connector mode, configure your Tailscale ACL policy:
 |------|-------------|------|---------|:--------:|
 | <a name="input_accept_dns"></a> [accept\_dns](#input\_accept\_dns) | For EC2 instances it is generally best to let Amazon handle the DNS configuration, not have Tailscale override it | `bool` | `false` | no |
 | <a name="input_advertised_routes"></a> [advertised\_routes](#input\_advertised\_routes) | List of advertised routes for the bastion host (required for subnet-router mode) | `list(string)` | `[]` | no |
+| <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Whether to create a security group. Set to false and provide security\_group\_id to use an existing one. | `bool` | `true` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EC2 instance type for the Tailscale node. Must be ARM64/Graviton (e.g., t4g, m6g, c6g) since the module uses an arm64 AMI. | `string` | `"t4g.micro"` | no |
 | <a name="input_mode"></a> [mode](#input\_mode) | Tailscale mode: 'subnet-router' or 'app-connector' | `string` | `"subnet-router"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Stack name to use in resource creation | `string` | n/a | yes |
-| <a name="input_security_group_id"></a> [security\_group\_id](#input\_security\_group\_id) | Optional existing security group ID. If provided, skips SG creation. | `string` | `null` | no |
-| <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | Name for the created security group. Ignored when security\_group\_id is provided. Defaults to 'tailscale-{name}'. | `string` | `null` | no |
+| <a name="input_security_group_id"></a> [security\_group\_id](#input\_security\_group\_id) | Existing security group ID to use. Required when create\_security\_group is false. | `string` | `null` | no |
+| <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | Name for the created security group. Only used when create\_security\_group is true. Defaults to 'tailscale-{name}'. | `string` | `null` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Subnet in which to deploy the EC2 instance | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_tailscale_tags"></a> [tailscale\_tags](#input\_tailscale\_tags) | List of tags to apply to the Tailscale node | `list(string)` | <pre>[<br/>  "tag:bastion"<br/>]</pre> | no |

--- a/cloud-init-userdata.tpl
+++ b/cloud-init-userdata.tpl
@@ -5,8 +5,8 @@ yum_repos:
     enabled: true
     repo_gpgcheck: true
     gpgcheck: false
-    baseurl: https://pkgs.tailscale.com/stable/amazon-linux/2/$basearch
-    gpgkey: https://pkgs.tailscale.com/stable/amazon-linux/2/repo.gpg
+    baseurl: https://pkgs.tailscale.com/stable/amazon-linux/2023/$basearch
+    gpgkey: https://pkgs.tailscale.com/stable/amazon-linux/2023/repo.gpg
 
 packages:
   - tailscale

--- a/cloud-init-userdata.tpl
+++ b/cloud-init-userdata.tpl
@@ -19,9 +19,8 @@ write_files:
 runcmd:
   - sysctl --system
   - systemctl enable --now tailscaled
-  - |
-    tailscale up \
-      --authkey "${auth_key}" \
-      --advertise-routes "${advertised_routes}" \
-      --hostname "${hostname}" \
-      --accept-dns="${accept_dns}"
+%{ if mode == "app-connector" ~}
+  - tailscale up --authkey "${auth_key}" --advertise-connector --hostname "${hostname}" --accept-dns="${accept_dns}"
+%{ else ~}
+  - tailscale up --authkey "${auth_key}" --advertise-routes "${advertised_routes}" --hostname "${hostname}" --accept-dns="${accept_dns}"
+%{ endif ~}

--- a/cloud-init-userdata.tpl
+++ b/cloud-init-userdata.tpl
@@ -19,8 +19,8 @@ write_files:
 runcmd:
   - sysctl --system
   - systemctl enable --now tailscaled
-%{ if mode == "app-connector" ~}
+%{ if mode == "app-connector" }
   - tailscale up --authkey "${auth_key}" --advertise-connector --hostname "${hostname}" --accept-dns="${accept_dns}"
-%{ else ~}
+%{ else }
   - tailscale up --authkey "${auth_key}" --advertise-routes "${advertised_routes}" --hostname "${hostname}" --accept-dns="${accept_dns}"
-%{ endif ~}
+%{ endif }

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -3,5 +3,5 @@ module "bastion_host" {
   name              = "foo"
   vpc_id            = data.aws_vpc.default.id
   subnet_id         = data.aws_subnets.default.ids[0]
-  advertised_routes = data.aws_vpc.default.cidr_block
+  advertised_routes = [data.aws_vpc.default.cidr_block]
 }

--- a/examples/default/versions.tf
+++ b/examples/default/versions.tf
@@ -2,12 +2,12 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.67.0"
+      version = ">= 5.20"
     }
     tailscale = {
       source  = "tailscale/tailscale"
-      version = "0.15.0"
+      version = "0.25.0"
     }
   }
-  required_version = "1.5.7"
+  required_version = ">= 1.5.6"
 }

--- a/main.tf
+++ b/main.tf
@@ -68,6 +68,10 @@ resource "aws_instance" "bastion_host_ec2" {
       condition     = var.mode != "app-connector" || length(var.advertised_routes) == 0
       error_message = "advertised_routes must not be set when mode is 'app-connector'. App connector routes are configured via Tailscale ACL policy."
     }
+    precondition {
+      condition     = var.create_security_group || var.security_group_id != null
+      error_message = "security_group_id is required when create_security_group is false."
+    }
   }
 
   tags = merge(var.tags, {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   security_group_name         = var.security_group_name != null ? var.security_group_name : "tailscale-${var.name}"
-  effective_security_group_id = var.security_group_id != null ? var.security_group_id : aws_security_group.allow_bastion_ssh_sg[0].id
+  effective_security_group_id = var.create_security_group ? aws_security_group.allow_bastion_ssh_sg[0].id : var.security_group_id
 }
 
 data "aws_ami" "amazon2023" {
@@ -78,7 +78,7 @@ resource "aws_instance" "bastion_host_ec2" {
 # Note: Named for historical reasons. Ingress is handled via Tailscale tunnel,
 # so no inbound rules are needed. This SG only allows outbound traffic.
 resource "aws_security_group" "allow_bastion_ssh_sg" {
-  count       = var.security_group_id == null ? 1 : 0
+  count       = var.create_security_group ? 1 : 0
   name        = local.security_group_name
   description = "Security group for Tailscale instance - egress only"
   vpc_id      = var.vpc_id

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ data "aws_ami" "amazon2023" {
 resource "aws_instance" "bastion_host_ec2" {
   depends_on                  = [tailscale_tailnet_key.bastion_key]
   ami                         = data.aws_ami.amazon2023.id
-  instance_type               = "t4g.micro"
+  instance_type               = var.instance_type
   associate_public_ip_address = true
   subnet_id                   = var.subnet_id
   user_data_replace_on_change = true
@@ -59,9 +59,9 @@ resource "aws_instance" "bastion_host_ec2" {
     instance_metadata_tags      = "disabled"
   }
 
-  tags = {
+  tags = merge(var.tags, {
     Name = "bastion-${var.name}"
-  }
+  })
 }
 
 # Note: Named for historical reasons. Ingress is handled via Tailscale tunnel,
@@ -95,9 +95,9 @@ module "ebs_kms_key" {
 
   aliases = ["bastion/${var.name}/ebs"]
 
-  tags = {
+  tags = merge(var.tags, {
     Name = "bastion-${var.name}"
-  }
+  })
 }
 
 resource "tailscale_tailnet_key" "bastion_key" {

--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,7 @@ resource "aws_instance" "bastion_host_ec2" {
       advertised_routes = join(",", var.advertised_routes)
       hostname          = "bastion-${var.name}"
       accept_dns        = var.accept_dns
+      mode              = var.mode
     }
   )
 

--- a/main.tf
+++ b/main.tf
@@ -3,12 +3,12 @@ locals {
   effective_security_group_id = var.security_group_id != null ? var.security_group_id : aws_security_group.allow_bastion_ssh_sg[0].id
 }
 
-data "aws_ami" "amazon2" {
+data "aws_ami" "amazon2023" {
   most_recent = true
 
   filter {
     name   = "name"
-    values = ["amzn2-ami-hvm-2*-gp2"]
+    values = ["al2023-ami-2*"]
   }
 
   filter {
@@ -26,7 +26,7 @@ data "aws_ami" "amazon2" {
 
 resource "aws_instance" "bastion_host_ec2" {
   depends_on                  = [tailscale_tailnet_key.bastion_key]
-  ami                         = data.aws_ami.amazon2.id
+  ami                         = data.aws_ami.amazon2023.id
   instance_type               = "t4g.micro"
   associate_public_ip_address = true
   subnet_id                   = var.subnet_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,5 +4,6 @@ output "incoming_security_group_id" {
 }
 
 output "instance_id" {
-  value = aws_instance.bastion_host_ec2.id
+  description = "EC2 instance ID of the bastion host"
+  value       = aws_instance.bastion_host_ec2.id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "incoming_security_group_id" {
-  description = "Security group ID for bastion sg"
-  value       = aws_security_group.allow_bastion_ssh_sg.id
+  description = "Security group ID used by the Tailscale instance"
+  value       = local.effective_security_group_id
 }
 
 output "instance_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "vpc_id" {
 
 variable "subnet_id" {
   type        = string
-  description = "Subnet in which to dpeloy the ec2 instance"
+  description = "Subnet in which to deploy the EC2 instance"
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,12 @@ variable "tailscale_tags" {
   }
 }
 
+variable "instance_type" {
+  type        = string
+  description = "EC2 instance type for the Tailscale node"
+  default     = "t4g.micro"
+}
+
 variable "security_group_id" {
   type        = string
   description = "Optional existing security group ID. If provided, skips SG creation."

--- a/variables.tf
+++ b/variables.tf
@@ -53,3 +53,15 @@ variable "tailscale_tags" {
     error_message = "All items in the tailscale_tags list must be prefixed with 'tag:'."
   }
 }
+
+variable "security_group_id" {
+  type        = string
+  description = "Optional existing security group ID. If provided, skips SG creation."
+  default     = null
+}
+
+variable "security_group_name" {
+  type        = string
+  description = "Name for the security group. Defaults to 'tailscale-{name}'."
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -19,9 +19,21 @@ variable "name" {
   description = "Stack name to use in resource creation"
 }
 
+variable "mode" {
+  description = "Tailscale mode: 'subnet-router' or 'app-connector'"
+  type        = string
+  default     = "subnet-router"
+
+  validation {
+    condition     = contains(["subnet-router", "app-connector"], var.mode)
+    error_message = "Mode must be 'subnet-router' or 'app-connector'."
+  }
+}
+
 variable "advertised_routes" {
   type        = list(string)
-  description = "List of advertised routes for the bastion host"
+  description = "List of advertised routes for the bastion host (only used in subnet-router mode)"
+  default     = []
 }
 
 variable "accept_dns" {

--- a/variables.tf
+++ b/variables.tf
@@ -65,9 +65,15 @@ variable "instance_type" {
   default     = "t4g.micro"
 }
 
+variable "create_security_group" {
+  type        = bool
+  description = "Whether to create a security group. Set to false and provide security_group_id to use an existing one."
+  default     = true
+}
+
 variable "security_group_id" {
   type        = string
-  description = "Optional existing security group ID. If provided, skips SG creation."
+  description = "Existing security group ID to use. Required when create_security_group is false."
   default     = null
 
   validation {
@@ -78,6 +84,6 @@ variable "security_group_id" {
 
 variable "security_group_name" {
   type        = string
-  description = "Name for the created security group. Ignored when security_group_id is provided. Defaults to 'tailscale-{name}'."
+  description = "Name for the created security group. Only used when create_security_group is true. Defaults to 'tailscale-{name}'."
   default     = null
 }

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     tailscale = {
       source  = "tailscale/tailscale"
-      version = "0.22.0"
+      version = "0.25.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     tailscale = {
       source  = "tailscale/tailscale"
-      version = "0.25.0"
+      version = ">= 0.18.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

- **App Connector mode**: New `mode` variable supports `subnet-router` (default) and `app-connector` for DNS-based routing in environments with overlapping CIDRs
- **Updated AMI**: Switch from Amazon Linux 2 to AL2023 for longer support lifecycle and more frequent updates
- **Provider flexibility**: Relax provider version constraints (`tailscale >= 0.18.0`, `aws >= 5.20`) and update KMS module to 4.2.0
- **Configurable instance type and security group**: New `instance_type`, `security_group_id`, and `security_group_name` variables for flexible deployments
- **Input validations**: Lifecycle preconditions prevent silent misconfiguration (empty routes in subnet-router mode, routes in app-connector mode), CIDR format validation, security group ID format validation, non-empty tailscale_tags check
- **Tags propagation**: All resources now merge `var.tags` consistently
- **README rewrite**: Comprehensive documentation with usage examples for both modes, comparison table, and ACL configuration guide
- **Bug fixes**: Fix example type error (`advertised_routes` string vs list), regenerate stale terraform-docs, fix typos

## Test plan

- [ ] Run `terraform init && terraform validate` against the module
- [ ] Run `terraform plan` with subnet-router mode and verify advertised routes appear in user data
- [ ] Run `terraform plan` with app-connector mode and verify `--advertise-connector` appears in user data
- [ ] Verify validation rejects empty `advertised_routes` in subnet-router mode
- [ ] Verify validation rejects non-empty `advertised_routes` in app-connector mode
- [ ] Verify validation rejects invalid CIDR in `advertised_routes`
- [ ] Verify validation rejects invalid `security_group_id` format
- [ ] Verify `security_group_id` bypass skips SG creation (count = 0)
- [ ] Verify example in `examples/default` passes `terraform validate`
- [ ] Deploy to a test VPC and confirm Tailscale node registers successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes instance bootstrapping and routing mode behavior (subnet-router vs app-connector) and migrates the underlying AMI, which could impact connectivity/registration if assumptions differ across environments.
> 
> **Overview**
> Adds **`app-connector` mode** alongside the default subnet-router behavior by branching `cloud-init-userdata.tpl` to run `tailscale up --advertise-connector` vs `--advertise-routes`, and introducing `mode` plus new validations/preconditions to prevent misconfiguration.
> 
> Updates the EC2 base to **Amazon Linux 2023 (arm64)**, makes the instance type configurable, and allows reusing an existing security group (`create_security_group`/`security_group_id`/`security_group_name`) while standardizing tag propagation via `merge(var.tags, ...)`.
> 
> Refreshes module dependencies and docs: relaxes provider constraints (`aws >= 5.20`, `tailscale >= 0.18.0`), bumps the KMS module, fixes the example to pass `advertised_routes` as a list, and rewrites `README.md` with usage and app-connector ACL guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca27505ac0945cdb4aa001946b34aa4192d13570. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->