### PR TITLE
feat!: make tailnet auth key ephemeral by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ module "tailscale_connector" {
 4. The connector resolves DNS names and automatically advertises routes for discovered IPs
 5. Traffic for configured domains flows through the connector
 
+**Node lifecycle:** By default, nodes are ephemeral and are automatically removed from the tailnet shortly after they go offline. This prevents stale nodes from accumulating when instances are replaced (e.g., during AMI updates). Set `ephemeral = false` if you need persistent node registrations — note that persistent nodes require manual removal from the Tailscale admin console when instances are replaced.
+
 **Note:** This module requires a public subnet with internet access. The node needs outbound connectivity to reach Tailscale's coordination servers.
 
 ## App Connector ACL Configuration
@@ -194,6 +196,7 @@ After deploying in app-connector mode, configure your Tailscale ACL policy:
 | <a name="input_accept_dns"></a> [accept\_dns](#input\_accept\_dns) | For EC2 instances it is generally best to let Amazon handle the DNS configuration, not have Tailscale override it | `bool` | `false` | no |
 | <a name="input_advertised_routes"></a> [advertised\_routes](#input\_advertised\_routes) | List of advertised routes for the bastion host (required for subnet-router mode) | `list(string)` | `[]` | no |
 | <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Whether to create a security group. Set to false and provide security\_group\_id to use an existing one. | `bool` | `true` | no |
+| <a name="input_ephemeral"></a> [ephemeral](#input\_ephemeral) | Register nodes as ephemeral. Ephemeral nodes are automatically removed from the tailnet when they go offline, preventing stale nodes from accumulating after instance replacement. | `bool` | `true` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EC2 instance type for the Tailscale node. Must be ARM64/Graviton (e.g., t4g, m6g, c6g) since the module uses an arm64 AMI. | `string` | `"t4g.micro"` | no |
 | <a name="input_mode"></a> [mode](#input\_mode) | Tailscale mode: 'subnet-router' or 'app-connector' | `string` | `"subnet-router"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Stack name to use in resource creation | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -117,7 +117,7 @@ module "ebs_kms_key" {
 
 resource "tailscale_tailnet_key" "bastion_key" {
   reusable      = true
-  ephemeral     = false
+  ephemeral     = var.ephemeral
   preauthorized = true
   expiry        = 7776000 # 90 days in seconds
   description   = "bastion-${var.name}"

--- a/variables.tf
+++ b/variables.tf
@@ -48,6 +48,12 @@ variable "accept_dns" {
 
 }
 
+variable "ephemeral" {
+  type        = bool
+  description = "Register nodes as ephemeral. Ephemeral nodes are automatically removed from the tailnet when they go offline, preventing stale nodes from accumulating after instance replacement."
+  default     = true
+}
+
 variable "tailscale_tags" {
   type        = list(string)
   description = "List of tags to apply to the Tailscale node"


### PR DESCRIPTION
## Summary

- Add `ephemeral` variable (bool, default `true`) to control whether Tailscale nodes are registered as ephemeral
- Wire `var.ephemeral` into `tailscale_tailnet_key.bastion_key` (previously hardcoded `false`)
- Document node lifecycle behavior and the new variable in the README

Every AMI refresh replaces the EC2 instance, but the old Tailscale node persisted forever because the auth key had `ephemeral = false`. This caused stale nodes to accumulate with auto-incrementing hostname suffixes (e.g., `bastion-stag-1`, `bastion-stag-2`). Ephemeral nodes are automatically removed from the tailnet shortly after going offline, solving this cleanly.

## Breaking Change

The default for `ephemeral` changes from `false` to `true`. Existing deployments will see the tailnet key and EC2 instance replaced on first apply. The last non-ephemeral node must be manually removed from the Tailscale admin console (one-time cleanup).

Users who need persistent node registrations can set `ephemeral = false`.

## Test plan

- [ ] `terraform fmt -check` passes
- [ ] `terraform validate` passes (ignoring pre-existing KMS module cache issues)
- [ ] `terraform plan` on existing deployment shows tailnet key replacement (`ephemeral: false → true`) and EC2 instance recreation
- [ ] After apply, verify only one node appears per deployment in Tailscale admin (no number suffixes)
- [ ] Verify `ephemeral = false` override works as escape hatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the default `ephemeral` setting will force replacement of the tailnet key (and thus instance re-registration) on upgrade, which can disrupt existing deployments until applied/cleaned up.
> 
> **Overview**
> Switches the generated `tailscale_tailnet_key` to be *ephemeral by default* to prevent stale Tailscale device registrations when the EC2 instance is replaced.
> 
> Adds a new `ephemeral` input (default `true`) wired into `tailscale_tailnet_key.bastion_key`, and documents the node lifecycle behavior plus the opt-out (`ephemeral = false`) in `README.md`/Terraform docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0842fa415bee354602c54ffaa6de757fd1ef3e1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->